### PR TITLE
Added tetrisrate stats and drought stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+*.swp
+*.swn
+*.swo

--- a/Game.lua
+++ b/Game.lua
@@ -16,6 +16,11 @@ Game = class(function(a,startFrame,startLevel)
 
   a.drought         = Drought() -- the drought object helps calculate droughts
 
+  a.droughtCounter  = 0
+  a.droughtMax      = 0
+  a.droughts        = 0
+  a.droughtAvg      = 0
+
   a.frames          = {} -- list of everything that happened every frame. indexed by frame nr.
   a.tetriminos      = {} -- list of all the tetriminos that spawned, indexed by frame.
   a.clears          = {} -- list of every clear that happened, indexed by frame.
@@ -77,15 +82,15 @@ function Game:dump()
 end
 
 -- this is all messy AF out the order is so arbitrary...
-function Game:lock (at, nt, b, frame, linesThisTurn)
-  game:addTetrimino(frame, nt, b)
+function Game:lock (current_tetrimino, next_tetrimino, board, frame, linesThisTurn)
+  game:addTetrimino(frame, current_tetrimino, board)
   if linesThisTurn > 0 then self:addClear(frame, linesThisTurn) end
 
-  local drought = self.drought:endTurn(linesThisTurn, b:isTetrisReady(), at, self)
-  self:handleSurplus(b, linesThisTurn, self.drought.paused)
+  local drought = self.drought:endTurn(linesThisTurn, board:isTetrisReady(), current_tetrimino, self)
+  self:handleSurplus(board, linesThisTurn, self.drought.paused)
   self.drought = drought
 
-  self:setTetrisReady(b:isTetrisReady())
+  self:setTetrisReady(board:isTetrisReady())
 
   return drought
 end
@@ -132,10 +137,11 @@ function Game:addClear (frame, nrLines)
   if nrLines == 4 then
     self.tetrises = self.tetrises + 1
     self.lastTetris = self.nrDrops -- todo: move that last part?
+  else
+    if nrLines == 3 then self.triples  = self.triples  + 1 end
+    if nrLines == 2 then self.doubles  = self.doubles  + 1 end
+    if nrLines == 1 then self.singles  = self.singles  + 1 end
   end
-  if nrLines == 3 then self.triples  = self.triples  + 1 end
-  if nrLines == 2 then self.doubles  = self.doubles  + 1 end
-  if nrLines == 1 then self.singles  = self.singles  + 1 end
   self.tetrisRate = (self.tetrises * 4) / self.nrLines
 end
 
@@ -150,9 +156,18 @@ function Game:setInitialTetriminos(globalFrame, first, second)
   end
 end
 
-function Game:addTetrimino (globalFrame, at, board)
-  print(globalFrame - self.startFrame, "added tetrimino:", getTetriminoNameById(at))
+function Game:addTetrimino (globalFrame, current_tetrimino, board)
   self.tetriminos[tostring(globalFrame - self.startFrame)] = at
+
+  if current_tetrimino == 18 then
+    self.droughtMax = self.droughtCounter > self.droughtMax and self.droughtCounter or self.droughtMax
+    self.droughtAvg = ((self.droughtAvg * self.droughts) + self.droughtCounter) / (self.droughts + 1)
+    self.droughts = self.droughts + 1
+    self.droughtCounter = 0
+  else
+    self.droughtCounter = self.droughtCounter + 1
+  end
+
   self.nrDrops = self.nrDrops + 1
 
   self.nrPressesPerTet = (self.nrPresses / 2) / self.nrDrops

--- a/Game.lua
+++ b/Game.lua
@@ -44,6 +44,8 @@ Game = class(function(a,startFrame,startLevel)
   a.doubles         = 0 -- number of doubles scored so far
   a.singles         = 0 -- number of singles scored so far
 
+  a.tetrisRate      = 0
+
   a.totalPause      = 0 -- total amount of time (blocks dropped) that a tetris ready well has been covered
   a.nrPauses        = 0 -- total number of times that a tetris ready well has been covered up
   a.totalDrought    = 0 -- total number of blocks dropped until a line comes, WHEN we become tetris ready.
@@ -134,6 +136,7 @@ function Game:addClear (frame, nrLines)
   if nrLines == 3 then self.triples  = self.triples  + 1 end
   if nrLines == 2 then self.doubles  = self.doubles  + 1 end
   if nrLines == 1 then self.singles  = self.singles  + 1 end
+  self.tetrisRate = (self.tetrises * 4) / self.nrLines
 end
 
 function Game:setInitialTetriminos(globalFrame, first, second)

--- a/GameReplay.lua
+++ b/GameReplay.lua
@@ -47,8 +47,13 @@ function GameReplay:toJson()
 end
 
 function GameReplay:writeReplay()
-  local f = io.open("replays/" .. self.filename, "w")
-  f:write(self:toJson())
-  f:flush()
-  f:close()
+  local path = statsPath .. 'replays/' .. self.filename
+  local f = io.open(path, "w")
+  if f == nil then
+    print("Could not read file: " .. path .. "\n")
+  else
+    f:write(self:toJson())
+    f:flush()
+    f:close()
+  end
 end

--- a/MetricsDisplay.lua
+++ b/MetricsDisplay.lua
@@ -1,6 +1,15 @@
 
 local displayMetrics = "yes" -- input.popup("Display Metrics?")
 
+function toPercent(n)
+  local _n = n *100
+  return _n % 1 >= 0.5 and math.ceil(_n) or math.floor(_n)
+end
+
+function stepDown(offs)
+  offs.y = offs.y + 10
+end
+
 function printMetrics(gui, memory, game)
 
   if displayMetrics == "no" then return; end
@@ -16,35 +25,46 @@ function printMetrics(gui, memory, game)
   local dasBackgroundColor
   if das < 10 then dasBackgroundColor = red else dasBackgroundColor = "#207005" end
   --gui.text(x1,y1+0,"DAS:" .. memory.readbyte(0x0046), "white", dasBackgroundColor)
+  --
+  --
   gui.text(x1,y1+0,"Clears:", "white", "black")
 
-  printMetric(gui, -10, "Singles:  ", game.singles)
-  printMetric(gui, 00, "Doubles:  ", game.doubles)
-  printMetric(gui, 10, "Triples:  ", game.triples)
-  printMetric(gui, 20, "Tetrises: ", game.tetrises)
+  local offs = {}
+  offs.x = 15
+  offs.y = 33
 
-  gui.text(x1,y1+60,"Other Metrics:", "white", "black")
-  printMetric(gui, 50, "Accmdation:" , game.accommodation)
-  printMetric(gui, 60, "Readiness:"  , game.lastReadiness)
-  printMetric(gui, 70, "Surplus: "   , game.lastSurplus)
-  printMetric(gui, 80, "Slope: "     , game.slope)
-  printMetric(gui, 90, "Bumpiness:"  , game.bumpiness)
+  printMetric(gui, offs, "Singles:  ", game.singles)
+  printMetric(gui, offs, "Doubles:  ", game.doubles)
+  printMetric(gui, offs, "Triples:  ", game.triples)
+  printMetric(gui, offs, "Tetrises: ", game.tetrises)
 
-  gui.text(x1,y1+130,"Averages:", "white", "black")
-  printMetric(gui, 120, "Clear:"  , game:avgClear())
-  printMetric(gui, 130, "Drought:", game:avgDrought())
-  printMetric(gui, 140, "Pause:"  , game:avgPause())
+  stepDown(offs)
+  gui.text(x1,offs.y, "Other Metrics:", "white", "black")
+  stepDown(offs)
+  printMetric(gui, offs, "Accmdation:" , game.accommodation)
+  printMetric(gui, offs, "Readiness:"  , game.lastReadiness)
+  printMetric(gui, offs, "Surplus: "   , game.lastSurplus)
+  printMetric(gui, offs, "Slope: "     , game.slope)
+  printMetric(gui, offs, "Bumpiness:"  , game.bumpiness)
+
+
+  stepDown(offs)
+  gui.text(x1,offs.y,"Averages:", "white", "black")
+  stepDown(offs)
+  printMetric(gui, offs, "TetrisRate:"  , toPercent(game.tetrisRate), "%")
+  printMetric(gui, offs, "Clear:"  , game:avgClear())
+  printMetric(gui, offs, "Drought:", game:avgDrought())
+  printMetric(gui, offs, "Pause:"  , game:avgPause())
 
   gui.drawrect(192,y1+70,192+30,y1+82,"black")
   gui.text(192,y1+72,"DAS:" .. memory.readbyte(0x0046), "white", dasBackgroundColor)
 end
 
-function printMetric(gui, yOffset,title,num)
-  local x1 = 12
-  local y2 = 43
+function printMetric(gui, offs,title,num, suffix)
   local numDisplay = ""
   if num ~= nil then numDisplay = round(num, 2) end
-  gui.text(x1,y2+yOffset, title .. numDisplay, "white", "black")
+  gui.text(offs.x,offs.y, title .. numDisplay .. (suffix or ""), "white", "black")
+  stepDown(offs)
 end
 
 function drawJoypad(gui, j)

--- a/MetricsDisplay.lua
+++ b/MetricsDisplay.lua
@@ -6,8 +6,8 @@ function toPercent(n)
   return _n % 1 >= 0.5 and math.ceil(_n) or math.floor(_n)
 end
 
-function stepDown(offs)
-  offs.y = offs.y + 10
+function stepDown(offs, len)
+  offs.y = offs.y + (len and len or 10)
 end
 
 function printMetrics(gui, memory, game)
@@ -16,10 +16,11 @@ function printMetrics(gui, memory, game)
 
   local red = "#a81605"
 
-  gui.drawrect(5,20,85,215,"black", red)
-
   local x1 = 8
-  local y1 = 23
+  local y1 = 20
+
+  gui.drawrect(5,10,85,225,"black", red)
+
 
   local das = memory.readbyte(0x0046)
   local dasBackgroundColor
@@ -31,14 +32,14 @@ function printMetrics(gui, memory, game)
 
   local offs = {}
   offs.x = 15
-  offs.y = 33
+  offs.y = y1 + 10
 
   printMetric(gui, offs, "Singles:  ", game.singles)
   printMetric(gui, offs, "Doubles:  ", game.doubles)
   printMetric(gui, offs, "Triples:  ", game.triples)
   printMetric(gui, offs, "Tetrises: ", game.tetrises)
 
-  stepDown(offs)
+  stepDown(offs, 5)
   gui.text(x1,offs.y, "Other Metrics:", "white", "black")
   stepDown(offs)
   printMetric(gui, offs, "Accmdation:" , game.accommodation)
@@ -47,16 +48,23 @@ function printMetrics(gui, memory, game)
   printMetric(gui, offs, "Slope: "     , game.slope)
   printMetric(gui, offs, "Bumpiness:"  , game.bumpiness)
 
-
+  stepDown(offs, 5)
+  gui.text(x1,offs.y,"Droughts:", "white", "black")
   stepDown(offs)
+  printMetric(gui, offs, "Current:"    , game.droughtCounter)
+  printMetric(gui, offs, "Max:"    , game.droughtMax)
+  printMetric(gui, offs, "Avg:"    , game.droughtAvg)
+
+
+  stepDown(offs, 5)
   gui.text(x1,offs.y,"Averages:", "white", "black")
   stepDown(offs)
   printMetric(gui, offs, "TetrisRate:"  , toPercent(game.tetrisRate), "%")
   printMetric(gui, offs, "Clear:"  , game:avgClear())
-  printMetric(gui, offs, "Drought:", game:avgDrought())
   printMetric(gui, offs, "Pause:"  , game:avgPause())
 
   gui.drawrect(192,y1+70,192+30,y1+82,"black")
+
   gui.text(192,y1+72,"DAS:" .. memory.readbyte(0x0046), "white", dasBackgroundColor)
 end
 

--- a/README.md
+++ b/README.md
@@ -41,28 +41,27 @@ Like Tetris Friends, but Tetris Metrics.
             
 ### Averages
 
+* Tetris rate
+
+  The percentage of the lines cleared that have been cleared by a tetris.
+
 * Conversion ratio
 
-  Number of tetrises / the number of times you've been ready for a tetris. 
-  
+  Number of tetrises / the number of times you've been ready for a tetris.
   Would be 1 if you never covered your well.
 
 * Average Clear
 
   The average number of lines you clear every time you clear lines.
-  
   Would be 4 if you only ever got tetrises.
 
 * Average Accommodation
   
    Running total of accommodation scores / number of tetriminos played.
-   
    Aim to get this score as close to 7 as possible.
-   
 * Average Max Height
 
   Running total of max heights / number of tetriminos played.
-  
   A perfect average max height would probably be less than 4, as you build up for a perfect tetris 
   (one that completely clears the board), and then get a tetris immediately. This, however, is certainly
   unattainable. It is currently unknown what a pro players average max height would be close to.
@@ -77,14 +76,12 @@ Like Tetris Friends, but Tetris Metrics.
 * Average Drought
 
   Running total of all droughts / number of droughts.
-  
   This should average out to be 7, since a line should come every 7 tetriminos on average.
   If you have a high average drought score, you probably had some rough RNG. If you survived, congrats.
   
 * Average Pause
 
   Running total of all pauses / number of pauses. 
-  
   Helps give an indication of how well you dig, if you are able to uncover your covered wells quickly.
   It's probably ideal to have a very low average pause score, but a higher average pause score
   might not necessarily indicate bad play, but simply brutal RNG.
@@ -92,14 +89,12 @@ Like Tetris Friends, but Tetris Metrics.
 * Average Surplus
 
   Running total of surplus scores / number of times tetris ready
-  
   If your surplus is very high, it might be an indication that you aren't burning enough.
   However, that might be totally okay if, for example, you are going for maxouts.
 
 * Average Tetris Readiness
 
   Running total of tetris readiness scores / number of times tetris ready.
-  
   You should probably aim to get your average tetris readiness score as low as possible. 
   You always want to be tetris ready, as fast as possible. Of course, don't sacrifice
   your board state to get there!
@@ -107,13 +102,10 @@ Like Tetris Friends, but Tetris Metrics.
 * Average Presses (Per tetrimino)
 
   Running total of all button presses / number of tetriminios played.
-  
   For non hyper-tappers, you should probably aim to keep this score low, as a high score 
   would probably indicate a lot of indecision, and probably a lot of last second presses.
-  
   Hyper-tappers probably also want to keep this score low, but their average score would 
   likely be much higher than that of a non-hyper-tapper. 
-  
   It is currently unknown what a pro players average presses per tetrimino would be close to
   for hyper-tappers and non-hyper-tappers.
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Like Tetris Friends, but Tetris Metrics.
   For each column, it gets the height of the highest block in it (in any column).
   Then, the lowest of all _those_ values is returned. The reason for this trickiness is because of holes.
    
-* Drought - The number of pieces it's been since you've been tetris ready. 
-  * Resets when a long bar comes (whether or not you use it to tetris). 
-  * Pauses if you cover your well.
-  * Resumes when you uncover it, or get a dirty tetris.
+* Drought - The number of perices since last I piece
+
 * Pause - The number of pieces it's been since you covered your well.
   * Resets when you clear your well or if you get a dirty tetris.
 * Surplus - When you become tetris ready, surplus is the number of blocks North of Perfect. 
@@ -75,10 +73,8 @@ Like Tetris Friends, but Tetris Metrics.
 
 * Average Drought
 
-  Running total of all droughts / number of droughts.
-  This should average out to be 7, since a line should come every 7 tetriminos on average.
-  If you have a high average drought score, you probably had some rough RNG. If you survived, congrats.
-  
+  The average number of pieces between I pieces.
+
 * Average Pause
 
   Running total of all pauses / number of pauses. 

--- a/tetris.lua
+++ b/tetris.lua
@@ -11,6 +11,22 @@ require("MetricsDisplay")
 
 currentInputs = joypad.get(1)
 
+POSIX = 'POSIX'
+WINDOWS = 'WINDOWS'
+
+if package.config:sub(1,1) == "/" then
+  osFamily = POSIX
+  statsPath = os.getenv("HOME") .. "/tetris_stats/"
+  os.execute("mkdir -p " .. statsPath)
+  os.execute("mkdir -p " .. statsPath .. "/replays/")
+else
+  -- TODO: Someone who has actually done something with
+  --       windows in the last decade should fix this
+  osFamily = WINDOWS
+  statsPath = "\\tetris_stats\\"
+end
+print("Running on " .. osFamily .. "\n")
+
 --
 function updateControllerInputs(game)
   game:addFrame(emu.framecount(),joypad.get(1), currentInputs)


### PR DESCRIPTION
Added tretris rate stats computed as the percentage of cleared liens that were cleared trough tetrises (Same as CTWC metric).

Redid drought calculations. Dow simply counts the number of pieces between I pieces as per CTWC metrics.